### PR TITLE
Switch ESP32 to AP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Rail Servo
 
-This project controls a stepper-driven linear rail using an ESP32. The ESP32 hosts a Wi-Fi web interface at `servo_rail.local` that lets a phone control position and speed with sliders and provides homing buttons for three limit switches.
+This project controls a stepper-driven linear rail using an ESP32. The ESP32 now starts as a Wi-Fi access point and hosts a web interface that lets a phone control position and speed with sliders and provides homing buttons for three limit switches.
 
 Default Wi-Fi credentials:
 
 - SSID: `rail_servo`
 - Password: `123456789`
+
+Connect to the `rail_servo` network (password `123456789`) and open the access point's IP address, typically `http://192.168.4.1/`.
 
 See `servo_rail.ino` for the firmware.

--- a/servo_rail/servo_rail.ino
+++ b/servo_rail/servo_rail.ino
@@ -119,15 +119,10 @@ void setup() {
   stepper.setAcceleration(ACCEL_MM_S2 * STEPS_PER_MM);
   stepper.setMaxSpeed(100 * STEPS_PER_MM); // default speed
 
-  WiFi.mode(WIFI_STA);
-  WiFi.begin(ssid, password);
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(500);
-    Serial.print('.');
-  }
-  Serial.println();
-  Serial.print("Connected to WiFi. IP: ");
-  Serial.println(WiFi.localIP());
+  WiFi.mode(WIFI_AP);
+  WiFi.softAP(ssid, password);
+  Serial.print("Access Point IP: ");
+  Serial.println(WiFi.softAPIP());
 
   MDNS.begin("servo_rail");
 


### PR DESCRIPTION
## Summary
- update WiFi setup to launch ESP32 as an access point
- document how to connect to the AP

## Testing
- `apt-get update -y`
- `apt-get install -y arduino-cli` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68872993e848832891b1730e6e4e7af3