### PR TITLE
Add configurable travel limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ Connect to the `rail_servo` network (password `123456789`) and open the access p
 
 ## Startup behavior
 
-When the ESP32 boots it performs a full homing sequence:
+The travel range and the location of switch&nbsp;1 are configurable in the
+firmware. When the ESP32 boots it performs a full homing sequence:
 
-1. It homes toward switch 1 to establish the negative end at −15&nbsp;cm.
-2. It then moves to find switch 2 and switch 3, storing their positions.
-3. After all switches are detected the current position is reset to zero and the web interface becomes available.
+1. It first seeks switch&nbsp;1 and assigns the configured `home1PosCm` value to
+   the current position.
+2. It then scans toward the positive end to record the positions of switches 2
+   and 3.
+3. Once switch&nbsp;3 (or the maximum range) is reached, that location becomes
+   position zero and the web interface becomes available.
 
 See `servo_rail.ino` for the firmware.


### PR DESCRIPTION
## Summary
- allow adjusting railMinCm, railMaxCm and home1PosCm
- generate HTML UI from these variables
- clamp movement to the configured limits
- document new behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887455edbe08328973439d9614762b8