### PR TITLE
Refine startup homing sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Connect to the `rail_servo` network (password `123456789`) and open the access p
 ## Startup behavior
 
 The travel range and the location of switch&nbsp;1 are configurable in the
-firmware. When the ESP32 boots it performs a full homing sequence:
+firmware. When the ESP32 boots it runs `fullHoming()` to perform a full sequence:
 
 1. It first seeks switch&nbsp;1 and assigns the configured `home1PosCm` value to
    the current position.


### PR DESCRIPTION
## Summary
- connect startup homing steps into a single sweep using new `fullHoming()`
- document the new function in the README

## Testing
- `git show -s --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889d87b8ed0832895af35ecb54e0818