### PR TITLE
Fix repeated homeAll

### DIFF
--- a/servo_rail/servo_rail.ino
+++ b/servo_rail/servo_rail.ino
@@ -363,4 +363,5 @@ void fullHoming(){
 
   // restore normal acceleration for regular moves
   stepper.setAcceleration(ACCEL_MM_S2 * STEPS_PER_MM);
+  flag = 0;  // stop repeating full homing
 }


### PR DESCRIPTION
## Summary
- stop repeating full homing by clearing flag when the routine completes

## Testing
- `platformio run` *(fails: blocked fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_688b1cae6dfc832898932debf6949ee5