### PR TITLE
Add slider position polling after homing

### DIFF
--- a/servo_rail/servo_rail.ino
+++ b/servo_rail/servo_rail.ino
@@ -122,6 +122,12 @@ function stopMotion(){
     .then(r=>r.text())
     .then(t=>{pos.value=parseInt(t);updateLabel();});
 }
+function updatePos(){
+  fetch('/pos')
+    .then(r=>r.text())
+    .then(t=>{pos.value=parseInt(t);updateLabel();});
+}
+setInterval(updatePos, 500);
 </script>
 </body>
 </html>
@@ -224,6 +230,10 @@ void setup() {
     abrt = 1;
     stepper.moveTo(stepper.currentPosition());
     stepper.setSpeed(0);
+    long pos10 = stepper.currentPosition() / STEPS_PER_MM + home1PosCm * 10;
+    req->send(200, "text/plain", String(pos10));
+  });
+  server.on("/pos", HTTP_GET, [](AsyncWebServerRequest *req){
     long pos10 = stepper.currentPosition() / STEPS_PER_MM + home1PosCm * 10;
     req->send(200, "text/plain", String(pos10));
   });


### PR DESCRIPTION
## Summary
- poll servo position periodically from the web page
- expose new `/pos` endpoint that returns current position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b2193119883289e4eca1f1259e8e0